### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,14 @@ FROM osrf/ros:noetic-desktop-full
 # install catkin tools first
 RUN apt update && apt install -y \
     python3-catkin-tools \ 
-    bash-completion htop
+    bash-completion \
+    htop
 
 # copy project to container temporarily for installing dependencies
 COPY src /home/src
-RUN /bin/bash -c "source /opt/ros/noetic/setup.bash" \ 
-&& rosdep update && rosdep install -y --from-paths /home/src --ignore-src --rosdistro noetic
+RUN /bin/bash -c "source /opt/ros/noetic/setup.bash && \
+    rosdep update --rosdistro=noetic && \
+    rosdep install -y --from-paths /home/src --ignore-src --rosdistro noetic"
 
 # install dependencies
 COPY Makefile /home/Makefile


### PR DESCRIPTION
On my machine, I am unable to build the image,
```
 => ERROR [ 4/10] RUN /bin/bash -c "source /opt/ros/noetic/setup.bash" && rosdep update && rosdep install -y --from-paths /home/src --ignore-src --rosdistro noetic                                             14.9s
------
 > [ 4/10] RUN /bin/bash -c "source /opt/ros/noetic/setup.bash" && rosdep update && rosdep install -y --from-paths /home/src --ignore-src --rosdistro noetic:
13.11 reading in sources list data from /etc/ros/rosdep/sources.list.d
13.11 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
13.11 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
13.11 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
13.11 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
13.11 Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
13.11 Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
13.11 Skip end-of-life distro "ardent"
13.11 Skip end-of-life distro "bouncy"
13.11 Skip end-of-life distro "crystal"
13.11 Skip end-of-life distro "dashing"
13.11 Skip end-of-life distro "eloquent"
13.11 Skip end-of-life distro "foxy"
13.11 Skip end-of-life distro "galactic"
13.11 Skip end-of-life distro "groovy"
13.11 Add distro "humble"
13.11 Skip end-of-life distro "hydro"
13.11 Skip end-of-life distro "indigo"
13.11 Skip end-of-life distro "iron"
13.11 Skip end-of-life distro "jade"
13.11 Add distro "jazzy"
13.11 Add distro "kilted"
13.11 Skip end-of-life distro "kinetic"
13.11 Skip end-of-life distro "lunar"
13.11 Skip end-of-life distro "melodic"
13.11 Skip end-of-life distro "noetic"
13.11 Add distro "rolling"
13.11 updated cache in /root/.ros/rosdep/sources.cache
13.11 Warning: running 'rosdep update' as root is not recommended.
13.11   You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.
14.76 WARNING: ROS_PYTHON_VERSION is unset. Defaulting to 3
14.76 ERROR: the following packages/stacks could not have their rosdep keys resolved
14.76 to system dependencies:
14.76 reference_costmap_generator: Cannot locate rosdep definition for [tf2_ros]
14.76 mppi_eval_msgs: Cannot locate rosdep definition for [std_msgs]
14.76 world_handler: Cannot locate rosdep definition for [ros_controllers]
14.76 groundtruth_odom_publisher: Cannot locate rosdep definition for [tf2_ros]
14.76 mppi_4d: Cannot locate rosdep definition for [navigation]
14.76 joy_controller: Cannot locate rosdep definition for [std_msgs]
14.76 map_visualizer: Cannot locate rosdep definition for [tf2_ros]
14.76 vel_driver: Cannot locate rosdep definition for [std_msgs]
14.76 mppi_3d: Cannot locate rosdep definition for [navigation]
14.76 mppi_h: Cannot locate rosdep definition for [navigation]
------
Dockerfile:11
--------------------
  10 |     COPY src /home/src
  11 | >>> RUN /bin/bash -c "source /opt/ros/noetic/setup.bash" \
  12 | >>> && rosdep update && rosdep install -y --from-paths /home/src --ignore-src --rosdistro noetic
  13 |
--------------------
ERROR: failed to solve: process "/bin/sh -c /bin/bash -c \"source /opt/ros/noetic/setup.bash\" && rosdep update && rosdep install -y --from-paths /home/src --ignore-src --rosdistro noetic" did not complete successfully: exit code: 1
make: *** [Makefile:20: setup_docker] Error 1
```

this PR fixes the problem